### PR TITLE
Remove unnecessary interface gymnastics

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package picofeed
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -43,10 +42,8 @@ func Refresh(ctx context.Context) error {
 
 	posts := fetchAll(ctx, feeds)
 
-	var output bytes.Buffer
-	foo := bufio.NewWriter(&output)
-	renderHtml(foo, posts, "Jan 2006")
-	foo.Flush()
+	output := bytes.NewBuffer([]byte{})
+	renderHtml(output, posts, "Jan 2006")
 
 	cfg, err := external.LoadDefaultAWSConfig(external.WithSharedConfigProfile("mine"))
 	if err != nil {
@@ -58,7 +55,7 @@ func Refresh(ctx context.Context) error {
 
 	putparams := &s3.PutObjectInput{
 		Bucket:      aws.String("hendry.iki.fi"),
-		Body:        aws.ReadSeekCloser(bytes.NewReader(output.Bytes())),
+		Body:        aws.ReadSeekCloser(output),
 		Key:         aws.String("feeds/index.html"),
 		ACL:         s3.ObjectCannedACLPublicRead,
 		ContentType: aws.String("text/html; charset=UTF-8"),


### PR DESCRIPTION
Hey Kai! I couldn't help but notice you seem to be doing some odd things with your byte buffer variables. 

I believe this should still work and be more idiomatic.

The [`bytes.Buffer`](https://godoc.org/bytes#Buffer) type is really handy as it provides a concrete implementation of basically all of the `io` interfaces, so you should never really need to wrangle things so much to get a buffer to satisfy a simple interface like the `io.ReadSeeker` expected by the `s3.PutObjectInput` struct. 

~~In fact, I doubt you should even need the `aws.ReadSeekCloser()` call either - just passing the `bytes.Buffer` right on through should work.~~ (Nevermind this part, `bytes.Buffer` doesn't provide a Seek method)

Additionally, I don't think you really need to call `bytes.NewBuffer` with an empty byte slice either, as I have done - as the docs mention, the `NewBuffer` function is intended for converting an existing byte slice to a `bytes.Buffer` - you could probably get away with simply instantiating a `bytes.Buffer` object:

```go
output := &bytes.Buffer{}
``` 

If you feel a bit iffy about how all the `io.Reader`, `io.Writer`, etc. interfaces work, you should really experiment with them a bit, they're pretty cool and powerful way of passing around disparate objects which all deal with data io, and it's very much a part of the "idiomatic go" philosophy.

_p.s._ I didn't really read all of your code or test it other than verifying it compiles as you seem to have it wired up pretty closely to the AWS SDK - is there an easy way to run it locally without refactoring a bunch?